### PR TITLE
export MOCK_CACHE = 'True' to docker builders

### DIFF
--- a/app/models/build_list.rb
+++ b/app/models/build_list.rb
@@ -525,6 +525,7 @@ class BuildList < ActiveRecord::Base
     if use_cached_chroot?
       sha1 = build_for_platform.cached_chroot(arch.name)
       cmd_params.merge!('CACHED_CHROOT_SHA1' => sha1) if sha1.present?
+      cmd_params.merge!('MOCK_CACHE' => 'True')
     end
     #cmd_params = cmd_params.map{ |k, v| "#{k}='#{v}'" }.join(' ')
 


### PR DESCRIPTION
When build is started with cached chroot export environment variable MOCK_CACHE with 'True' value so docker-builder script build-rpm.sh can make use of it.

When build is started without cached chroot then MOCK_CACHE is empty